### PR TITLE
Add support for drush color

### DIFF
--- a/docker-src/cms/Dockerfile
+++ b/docker-src/cms/Dockerfile
@@ -105,12 +105,14 @@ ENTRYPOINT ["drupalstand-entrypoint"]
 
 WORKDIR /var/www
 
-RUN  apk add --no-cache --virtual \
+RUN  apk add --no-cache \
              git \
              curl \
              vim \
              unzip \
              wget \
+             ncurses \
+             ncurses-terminfo \
   && apk add --no-cache --virtual .build-deps \
              # unknown needed
              autoconf \
@@ -128,6 +130,9 @@ RUN  apk add --no-cache --virtual \
   && echo 'xdebug.remote_connect_back="${CONNECTBACK}"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.remote_host=192.168.65.1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && apk del .build-deps
+
+# color avaiable thanks to ncurses packages above
+ENV TERM xterm-256color
 
 COPY docker-src/cms/php-conf.d.dev/* /usr/local/etc/php/conf.d/
 


### PR DESCRIPTION
add support for color by adding the ncurses package. This package includes tput which drush uses to determine support