### PR TITLE
PHP memory limit  bad char bug

### DIFF
--- a/docker-src/cms/php-conf.d/resources.ini
+++ b/docker-src/cms/php-conf.d/resources.ini
@@ -1,3 +1,3 @@
 ; Allowed Memory Size of 256 MB
-memory_limit = 268435456¶
+memory_limit = 268435456
 max_execution_time = 0


### PR DESCRIPTION
PHP memory limit had a paragraph char at the end. It didn't break anything but is a bug. Showed up on the Drupal report page