### PR TITLE
Update drupal.conf

### DIFF
--- a/docker-src/cms/nginx/drupal.conf
+++ b/docker-src/cms/nginx/drupal.conf
@@ -5,6 +5,7 @@ server {
     ssl_certificate public.pem;
     ssl_certificate_key private.key;
     root /var/www/webroot; ## <-- Your only path reference.
+    client_max_body_size 50m;
 
     location = /favicon.ico {
         log_not_found off;


### PR DESCRIPTION
Nginx imposes a default upload limit of 1MB unless this setting is changed.  This overrides the PHP settings.