### PR TITLE
Docker extra-hosts must be an IP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LABLE_BASE := ${IMAGE_MAINTAINER}/${PROJECT}
 ifeq ($(DOCKER_HOST_IP), )
   export DOCKER_INTERNAL_IP=$(shell ip route | grep -E '(default|docker0)' | grep -Eo '([0-9]+\.){3}[0-9]+' | tail -1)
 else
-  export DOCKER_INTERNAL_IP=host.docker.internal
+  export DOCKER_INTERNAL_IP=$(DOCKER_HOST_IP)
 endif
 
 ifeq ($(UNAME), Linux)


### PR DESCRIPTION
Per the docker-compose documentation the extra_hosts variable must be an IP address.
https://docs.docker.com/compose/compose-file/#extra_hosts

The ifeq matches if equal to nothing. Else the host ip was found and thus we should use it.